### PR TITLE
Add husky and pre-commit hook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 * @galaxypedia-wiki/development-team
 
 content/wiki/ @galaxypedia-wiki/staff
+
+.husky/ @smallketchup82

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build Site
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      HUSKY: 0
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,6 +13,8 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,7 @@
+// Skip Husky install in CI
+// https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+if (process.env.CI === 'true') {
+    process.exit(0)
+  }
+  const husky = (await import('husky')).default
+  console.log(husky())

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
-pnpm exec prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+pnpm exec prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --check --ignore-unknown
 
 git update-index --again

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+pnpm exec prettier $(git diff --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+git update-index --again

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+echo "Running prettier"
+
 pnpm exec prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --check --ignore-unknown
 
 git update-index --again

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
-pnpm exec prettier $(git diff --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+pnpm exec prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+
 git update-index --again

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
 echo "Running prettier"
 
 pnpm exec prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --check --ignore-unknown
-
-git update-index --again

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.husky/install.mjs

--- a/package.json
+++ b/package.json
@@ -4,18 +4,20 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "format": "prettier --write",
+    "format": "prettier --write --ignore-unknown .",
     "linkrot": "linkinator ./public --config ./linkinator.config.json",
     "pagefind": "pagefind --site public",
     "index": "pnpm pagefind",
     "build": "hugo && pnpm pagefind",
     "ci": "hugo --minify --baseURL '$PAGEURL' && pnpm pagefind && pnpm linkrot",
-    "serve": "pnpm build && hugo server -D"
+    "serve": "pnpm build && hugo server -D",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "husky": "^9.1.7",
     "prettier": "^3.4.2",
     "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-tailwind-css": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "hugo && pnpm pagefind",
     "ci": "hugo --minify --baseURL '$PAGEURL' && pnpm pagefind && pnpm linkrot",
     "serve": "pnpm build && hugo server -D",
-    "prepare": "husky"
+    "prepare": "node .husky/install.mjs"
   },
   "keywords": [],
   "author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
         specifier: 4.0.0-beta.5
         version: 4.0.0-beta.5
     devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -544,6 +547,14 @@ packages:
         integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
       }
     engines: { node: ">= 14" }
+
+  husky@9.1.7:
+    resolution:
+      {
+        integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution:
@@ -1265,6 +1276,8 @@ snapshots:
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
+
+  husky@9.1.7: {}
 
   is-extglob@2.1.1: {}
 


### PR DESCRIPTION
This PR adds husky, a tool to automate installation of Git Hooks when installing pnpm dependencies. It also adds a pre-commit script and sets @smallketchup82 as the CODEOWNER for the `.husky` directory, where Git Hooks are stored.

See the [husky documentation](https://typicode.github.io/husky/) for more information.