### PR TITLE
Fix ci baseurl again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,10 @@ jobs:
             trimmed=${slug:0:28} # cloudflare pages trims the subdomain to 28 characters
             result=${trimmed%-}
 
-            export HUGO_PAGE_URL="https://${result}.galaxypedia.pages.dev"
+            export HUGO_BASE_URL="https://${result}.galaxypedia.pages.dev"
           fi
-          echo $HUGO_PAGE_URL
-          hugo --minify --baseURL "$HUGO_PAGE_URL"
+          echo $HUGO_BASE_URL
+          hugo --minify --baseURL "$HUGO_BASE_URL"
       - name: Build Pagefind index
         run: pnpm pagefind
       - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,10 @@ jobs:
           if [ "$HUGO_ENVIRONMENT" = "production" ]; then
             export HUGO_PAGE_URL="https://v2.galaxypedia.org"
           else
-            export HUGO_PAGE_URL="https://${ACTOR}-${REF}.galaxypedia.pages.dev"
+            slug="${ACTOR}-${REF}"
+            trimmed=${slug:0:28}
+            result=${trimmed%-}
+            export HUGO_PAGE_URL="https://${result}.galaxypedia.pages.dev"
           fi
           echo $HUGO_PAGE_URL
           hugo --minify --baseURL "$HUGO_PAGE_URL"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,22 @@ jobs:
           HUGO_ENVIRONMENT: ${{ inputs.production && 'production' || 'development' }}
           ACTOR: ${{ github.event.pull_request.user.login }}
           REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
+          echo "Building for $HUGO_ENVIRONMENT"
           if [ "$HUGO_ENVIRONMENT" = "production" ]; then
             export HUGO_PAGE_URL="https://v2.galaxypedia.org"
           else
-            slug="${ACTOR}-${REF}"
+            if [ "$BASE_REPO" = "$HEAD_REPO" ]; then
+              slug="${REF}"
+            else
+              slug="${ACTOR}-${REF}"
+            fi
+
             trimmed=${slug:0:28}
             result=${trimmed%-}
+
             export HUGO_PAGE_URL="https://${result}.galaxypedia.pages.dev"
           fi
           echo $HUGO_PAGE_URL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
               slug="${ACTOR}-${REF}"
             fi
 
-            trimmed=${slug:0:28}
+            trimmed=${slug:0:28} # cloudflare pages trims the subdomain to 28 characters
             result=${trimmed%-}
 
             export HUGO_PAGE_URL="https://${result}.galaxypedia.pages.dev"


### PR DESCRIPTION
woohoo i'm going insane  
this pr fixes the baseurl in ci builds where the actor and ref name combined exceed 28 characters and also fixes pr deployments when the branch being deployed from exists on the base repository