### PR TITLE
Redirect to BaseURL in CI deployments

### DIFF
--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -1,0 +1,8 @@
+(function (params) {
+  const baseUrl = params.baseUrl.replace(/\/$/, "");
+  const url = new URL(window.location.href);
+  if (url.pathname.startsWith(baseUrl)) {
+    const newUrl = new URL(url.pathname.replace(baseUrl, ""), baseUrl);
+    window.location.href = newUrl.toString();
+  }
+})("@params");

--- a/layouts/partials/site/head.html
+++ b/layouts/partials/site/head.html
@@ -30,6 +30,16 @@
   <title>
     {{ if .Title }}Galaxypedia - {{ .Title }}{{ else }}Galaxypedia{{ end }}
   </title>
+  {{ if getenv "CI" }}
+    {{ $jsBuildOpts := dict "minify" false "params" (dict "baseUrl" (.Site.BaseURL | safeJS)) }}
+    {{ with resources.Get "js/redirect.js" | js.Build $jsBuildOpts | fingerprint }}
+      <script
+        src="{{ .RelPermalink }}"
+        integrity="{{ .Data.Integrity }}"
+        crossorigin="anonymous"
+      ></script>
+    {{ end }}
+  {{ end }}
   {{ if hugo.IsProduction }}
     <script
       src="https://js.sentry-cdn.com/79a2541d247797be5c61ecfd7c307b0e.min.js"


### PR DESCRIPTION
Currently, if you go on any PR and click on a link from the GitHub Deployments bot, it'll take you to the wrong URL. Normally it'd work fine, but because Hugo depends on `BaseURL` being correct, it breaks. This PR fixes that issue by automatically redirecting to `BaseURL` if you access the site from another domain, only when building in CI.