### PR TITLE
Add average turret/spinal dps back to the infobox

### DIFF
--- a/layouts/shortcodes/shipInfobox.html
+++ b/layouts/shortcodes/shipInfobox.html
@@ -69,6 +69,14 @@
   <p><b>Huge Turrets:</b> {{ index $shipData "huge_turrets" }}</p>
   <p><b>(F) Spinal:</b> {{ index $shipData "spinal_1" }}</p>
   <p><b>(G) Spinal:</b> {{ index $shipData "spinal_2" }}</p>
+  <p>
+    <b>Average Turret DPS:</b>
+    {{ index $shipData "turret_dps" }}
+  </p>
+  <p>
+    <b>Average Spinal DPS:</b>
+    {{ index $shipData "spinal_dps" }}
+  </p>
   <p><b>Max Turret Range:</b> {{ index $shipData "m_class_range" }}</p>
   <p><b>Recom. Turret Range:</b> {{ index $shipData "r_class_range" }}</p>
   <p><b>Mining Lasers:</b> {{ index $shipData "mining_lasers" }}</p>


### PR DESCRIPTION
does what it says on the tin, not sure why this was removed / not present in the first place.