### PR TITLE
Add docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+elasticsearch/
+.env
+public/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# set up base image and set up corepack
+FROM hugomods/hugo:node-git-0.139.5 AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install -g corepack@latest
+RUN corepack enable
+
+FROM base AS dependencies
+COPY pnpm-lock.yaml /src
+WORKDIR /src
+RUN pnpm fetch --prod
+COPY . /src
+RUN pnpm install --frozen-lockfile --prod
+
+FROM base AS final
+COPY --from=dependencies /src /src
+WORKDIR /src
+EXPOSE 1313
+
+# build the site once so that we can index it
+RUN pnpm build:min
+CMD ["hugo", "server", "--minify", "-D"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  galaxypedia:
+    ports:
+      - "1313:1313"
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pagefind": "pagefind --site public",
     "index": "pnpm pagefind",
     "build": "hugo && pnpm pagefind",
+    "build:min": "hugo --minify && pnpm pagefind",
     "ci": "hugo --minify --baseURL '$PAGEURL' && pnpm pagefind && pnpm linkrot",
     "serve": "pnpm build && hugo server -D"
   },


### PR DESCRIPTION
this PR adds in docker configuration to allow for serving the galaxypedia from a docker container.

the hope is that this can simplify the work needed to begin developing on the galaxypedia. instead of having to manually download a bunch of different dependencies, it is all done for you inside of a container.

the dockerfile's base comes with hugo, git, and nodejs installed. we copy the files from the host to the container, install pnpm, install the dependencies, then we build the site and index it, and finally run it from hugo's integrated webserver. we minify the code and stuff to keep it simple, but also add in developmental stuff like rendering drafts.